### PR TITLE
Remove included NPM reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,26 +33,18 @@ Think **[webwhiteboard.com](https://webwhiteboard.com)** but on your own server.
    cd whiteboard-app
    ```
 
-2. **Build and start the containers:**
+2. **Build and start the container:**
    ```bash
-   docker compose up --build
+   docker compose up --build -d
    ```
-   If you already run your own instance of **Nginx Proxy Manager**, you can
-   launch only the whiteboard service by using the optional compose file:
-   ```bash
-   docker compose -f docker-compose.external-npm.yml up --build -d
-   ```
-   This file attaches the container to an external network named
-   `npm_proxy` so your existing NPM can forward requests to `whiteboard:3000`.
-   Replace `npm_proxy` with whatever network name your NPM uses (check with
-   `docker network ls`).
+   The app listens on `127.0.0.1:3000` so it is only accessible from the
+   host machine. Configure your own reverse proxy (e.g. Nginx) to expose it
+   on your network if desired.
 
-3. **Access Nginx Proxy Manager:**
-   The compose file now includes an [Nginx Proxy Manager](https://nginxproxymanager.com/) container. Open `http://localhost:81` and log in with the default credentials to configure a new proxy host that forwards to `whiteboard:3000`.
-
-4. **Open your browser:**
-   Navigate to `http://localhost:3000` (replace `localhost` with your server's IP or domain).
-5. **Invite a friend:**
+3. **Open your browser:**
+   Navigate to `http://localhost:3000` on the host or through your reverse
+   proxy.
+4. **Invite a friend:**
    Share the URL. Anyone who visits can draw on the whiteboard in real time.
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,20 +3,8 @@ services:
   whiteboard:
     build: .
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     volumes:
       - ./public:/app/public
     restart: unless-stopped
- 
-  npm:
-    image: 'jc21/nginx-proxy-manager:latest'
-    container_name: npm
-    restart: unless-stopped
-    ports:
-      - '3380:80'
-      - '3381:81'
-      - '3443:443'
-    volumes:
-      - ./npm/data:/data
-      - ./npm/letsencrypt:/etc/letsencrypt
 


### PR DESCRIPTION
## Summary
- drop the `npm` service from the default compose file
- bind the whiteboard service to localhost only
- update the README with new instructions

## Testing
- `npm test` (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_685aa5bba1908321bfc410cd440d557d