### PR TITLE
Fix Dockerfile for local npm deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:18-alpine
 WORKDIR /app
 COPY server/package*.json ./server/
-RUN cd server && npm install && cd ..
 COPY server ./server
+RUN cd server && npm install && cd ..
 COPY public ./public
 EXPOSE 3000
 CMD ["node", "server/index.js"]


### PR DESCRIPTION
## Summary
- ensure node_modules are kept after build

## Testing
- `npm install`
- `node index.js`

------
https://chatgpt.com/codex/tasks/task_e_685aa6fa94988321a9f8ddc6838c758b